### PR TITLE
remove usage of @electron/remote

### DIFF
--- a/js/webcomponents/bisweb_cpmelement.js
+++ b/js/webcomponents/bisweb_cpmelement.js
@@ -165,7 +165,7 @@ class CPMElement extends HTMLElement {
             bis_webutil.createMenuItem(topmenu, ''); // separator
             bis_webutil.createMenuItem(topmenu, 'Show JavaScript Console',
                                        function () {
-                                           window.BISELECTRON.remote.getCurrentWindow().toggleDevTools();
+                                           window.BISELECTRON.toggleDevTools();
                                        });
         } else {
             bis_webfileutil.createFileSourceSelector(topmenu);

--- a/js/webcomponents/bisweb_mainviewerapplication.js
+++ b/js/webcomponents/bisweb_mainviewerapplication.js
@@ -1087,7 +1087,7 @@ class ViewerApplicationElement extends HTMLElement {
             webutil.createMenuItem(hmenu, ''); // separator
             webutil.createMenuItem(hmenu, 'Show JavaScript Console',
                                    function () {
-                                       window.BISELECTRON.remote.getCurrentWindow().toggleDevTools();
+                                       window.BISELECTRON.toggleDevTools();
                                    });
             userPreferences.safeGetItem('electonzoom').then( (v) => {
                 let z=v || 1.0;

--- a/js/webtest/bisweb_regressiontestelement.js
+++ b/js/webtest/bisweb_regressiontestelement.js
@@ -535,7 +535,7 @@ var run_tests=async function(testlist,firsttest=0,lasttest=-1,testname='All',use
     oldTestDataRootDirectory=testDataRootDirectory;
     
     if (webutil.inElectronApp()) {
-        window.BISELECTRON.remote.getCurrentWindow().openDevTools();
+        window.BISELECTRON.toggleDevTools();
     }
     let url=window.document.URL;
     let index=url.indexOf('.html');

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "author": "Yale BioImageSuite Web Team",
     "license": "Apache",
     "dependencies": {
-        "@electron/remote": "1.0.2",
         "amazon-cognito-auth-js": "1.3.2",
         "atob": "2.1.2",
         "bootbox": "4.4.0",

--- a/web/biselectron.js
+++ b/web/biselectron.js
@@ -40,7 +40,6 @@ let getTime = function() {
 // -------------------------------------------------------------------------------
 
 const electron = require('electron');
-require('@electron/remote/main').initialize();
 require('electron-debug')({showDevTools: false,
                            enabled : true});
 
@@ -56,6 +55,18 @@ const BrowserWindow = electron.BrowserWindow;  // Module to create native browse
 const ipcMain = electron.ipcMain;
 const shell=electron.shell;
 const toolfile=require('./images/tools.json');
+
+ipcMain.on('TOGGLE_DEV_TOOLS', (e) => {
+    e.sender.toggleDevTools();
+})
+
+ipcMain.handle('SHOW_SAVE_DIALOG', (e, opts) => {
+    return electron.dialog.showSaveDialog(null, opts)
+})
+
+ipcMain.handle('SHOW_OPEN_DIALOG', (e, opts) => {
+    return electron.dialog.showOpenDialog(null, opts)
+})
 
 const state = {
     winlist : [null],

--- a/web/biselectron.js
+++ b/web/biselectron.js
@@ -284,7 +284,6 @@ const createWindow=function(index,fullURL) {
                                                 nodeIntegration: false,
                                                 preload: preload,
                                                 contextIsolation: false,
-                                                enableRemoteModule : true,
                                             },
                                             autoHideMenuBar : true,
                                             icon: __dirname+'/images/favicon.ico'});

--- a/web/bispreload.js
+++ b/web/bispreload.js
@@ -20,7 +20,6 @@
 "use strict";
 
 const electron= require('electron');
-const remote  = require('@electron/remote');
 
 window.BISELECTRON = {
     // ----------------------------------------------------
@@ -37,8 +36,17 @@ window.BISELECTRON = {
     child_process : require('child_process'),
     colors : require('colors/safe'),
     ipc : electron.ipcRenderer,
-    dialog : remote.dialog,
-    remote : remote,
+    dialog : {
+        showSaveDialog: (_unused, options) => {
+            return electron.ipcRenderer.invoke('SHOW_SAVE_DIALOG', options)
+        },
+        showOpenDialog: (_unused, options) => {
+            return electron.ipcRenderer.invoke('SHOW_OPEN_DIALOG', options)
+        }
+    },
+    toggleDevTools: () => {
+        electron.ipcRenderer.send('TOGGLE_DEV_TOOLS')
+    },
     Buffer : Buffer,
     electron : electron,
 };

--- a/web/exportexample.js
+++ b/web/exportexample.js
@@ -37,7 +37,7 @@ const fn = function(viewer,img) {
 window.onload = function() {
 
     if (bisweb.getEnvironment() === "electron") {
-        window.BISELECTRON.remote.getCurrentWindow().toggleDevTools();
+        window.BISELECTRON.toggleDevTools();
         $('.navbar-fixed-bottom').remove();
     }
 

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,6 @@
     "description": "The Electron version of BioImageSuite Web",
     "main": "biselectron.js",
     "dependencies": {
-        "@electron/remote": "1.0.2",
         "commander": "2.16.0",
         "colors": "1.1.2",
         "electron-debug": "1.5.0",

--- a/web/tfjsexample.js
+++ b/web/tfjsexample.js
@@ -68,7 +68,7 @@ let run_tf_module=async function(img) {
 window.onload = function() {
 
     if (bisweb.getEnvironment() === "electron") {
-        window.BISELECTRON.remote.getCurrentWindow().toggleDevTools();
+        window.BISELECTRON.toggleDevTools();
         $('.navbar-fixed-bottom').remove();
     }
     

--- a/web/tfjsexample2.js
+++ b/web/tfjsexample2.js
@@ -71,7 +71,7 @@ let run_tf_module=async function(img) {
 window.onload = function() {
 
     if (bisweb.getEnvironment() === "electron") {
-        window.BISELECTRON.remote.getCurrentWindow().toggleDevTools();
+        window.BISELECTRON.toggleDevTools();
         $('.navbar-fixed-bottom').remove();
     }
     


### PR DESCRIPTION
Hey there! I'm the author of @electron/remote, and I'm trying to get fewer
people to use it :) I wrote a bit about [some of the reasons
why](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31).

I was looking at projects that depend on @electron/remote, and I noticed that
bisweb's usage was quite straightforwardly replaceable with a few IPC handlers.

Feel free to ignore this if you're not interested, but I hope this is helpful &
allows you to remove your dependency on the @electron/remote module!
